### PR TITLE
Update QueryBuilder.php

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -153,7 +153,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
      * @param array $rows the rows to be batch inserted into the table
      * @return string the batch INSERT SQL statement
      */
-    public function batchInsert($table, $columns, $rows)
+    public function batchInsert($table, $columns, $rows, &$params = []))
     {
         $schema = $this->db->getSchema();
         if (($tableSchema = $schema->getTableSchema($table)) !== null) {


### PR DESCRIPTION
fix  this error :  

 "name": "PHP Compile Error",
    "message": "Declaration of edgardmessias\\db\\informix\\QueryBuilder::batchInsert($table, $columns, $rows) must be compatible with yii\\db\\QueryBuilder::batchInsert($table, $columns, $rows, &$params = [])",
    "code": 64,
    "type": "yii\\base\\ErrorException",
    "file": "/var/www/html/ssoproject/vendor/edgardmessias/yii2-informix/src/QueryBuilder.php",
    "line": 156,
    "stack-trace": [
        "#0 [internal function]: yii\\base\\ErrorHandler->handleFatalError()",
        "#1 {main}"
    ]
}
This bug is seen in the latest Yii versions >=2.0.4 and does not affect older versions
The latest versions contain this change
yii\\db\\QueryBuilder::batchInsert($table, $columns, $rows, &$params = [])"